### PR TITLE
Add SQLite migration and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,30 @@ gunicorn -b :5050 main:app
 
 Run:
 GOOGLE_APPLICATION_CREDENTIALS=secrets/google-credentials.json  gunicorn -k gthread -b :8891 main:app --timeout 120 --workers 2 --threads 1                 
+
+## SQLite Support
+
+The project now includes simple SQLite models located in `sqlite_models.py`.
+To migrate existing Google Cloud Datastore (NDB) data into SQLite run:
+
+```bash
+source .venv/bin/activate
+python migrate_ndb_to_sqlite.py YOUR_GCP_PROJECT_ID --db wordgames.db
+```
+The SQLite path can also be set using the `WORDGAMES_DB` environment variable.
+A helper CLI `sqlite_cli.py` is provided for quick inspection of tables:
+
+```bash
+python sqlite_cli.py users --limit 5 --db wordgames.db
+```
+
+## Flash SWF Migration
+
+Old Flash games stored in Google Cloud Storage can be copied into an S3/R2 bucket using `migrate_swf_to_s3.py`:
+
+```bash
+python migrate_swf_to_s3.py games.addictingwordgames.com addictionwordgamesstatic.addictingwordgames.com
+```
+Use `--prefix` to limit which objects are copied. The script supports `--dry-run`
+and `--skip-existing` flags for safer migrations. Bucket names may also be
+provided via the `GCS_BUCKET` and `S3_BUCKET` environment variables.

--- a/migrate_ndb_to_sqlite.py
+++ b/migrate_ndb_to_sqlite.py
@@ -1,0 +1,43 @@
+"""Migrate data from Google Cloud NDB to local SQLite database."""
+
+from typing import Iterable
+
+from google.cloud import ndb
+
+from models import User, Game, Score, HighScore, Achievement, Photo
+from sqlite_models import SQLiteDB
+
+
+def _copy_query(query: Iterable, table: str, cols: Iterable[str], db: SQLiteDB):
+    for entity in query:
+        values = [getattr(entity, c) for c in cols]
+        db.insert(table, cols, values)
+
+
+def migrate(project: str, sqlite_path: str = "wordgames.db") -> None:
+    client = ndb.Client(project=project)
+    db = SQLiteDB(sqlite_path)
+    with client.context():
+        _copy_query(User.query(), "users",
+                    ["id", "cookie_user", "name", "email", "profile_url",
+                     "access_token", "has_purchased"], db)
+        _copy_query(Game.query(), "games",
+                    ["title", "urltitle", "description", "instructions",
+                     "url", "width", "height", "imgwidth", "imgheight"], db)
+        _copy_query(Score.query(), "scores",
+                    ["user", "score", "difficulty", "timedMode"], db)
+        _copy_query(HighScore.query(), "highscores",
+                    ["user", "score", "difficulty", "timedMode"], db)
+        _copy_query(Achievement.query(), "achievements",
+                    ["user", "type"], db)
+        _copy_query(Photo.query(), "photos", ["title", "full_size_image"], db)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="migrate datastore to sqlite")
+    parser.add_argument("project", help="Google Cloud project id")
+    parser.add_argument("--db", default="wordgames.db", help="SQLite DB path")
+    args = parser.parse_args()
+    migrate(args.project, args.db)

--- a/migrate_swf_to_s3.py
+++ b/migrate_swf_to_s3.py
@@ -1,0 +1,86 @@
+"""Migrate SWF files from Google Cloud Storage to an S3 bucket."""
+
+import argparse
+import logging
+import os
+from typing import Iterable
+
+from google.cloud import storage
+import boto3
+
+
+def _migrate(
+    gcs_client: storage.Client,
+    s3_client,
+    gcs_bucket: str,
+    s3_bucket: str,
+    prefix: str = "",
+    dry_run: bool = False,
+    skip_existing: bool = False,
+) -> None:
+    """Internal helper used so we can inject clients for testing."""
+    bucket = gcs_client.bucket(gcs_bucket)
+    blobs: Iterable = gcs_client.list_blobs(bucket, prefix=prefix)
+    from tqdm import tqdm
+
+    for blob in tqdm(list(blobs)):
+        if skip_existing:
+            try:
+                s3_client.head_object(Bucket=s3_bucket, Key=blob.name)
+                logging.info("skip %s", blob.name)
+                continue
+            except Exception:
+                pass
+        if dry_run:
+            logging.info("would upload %s", blob.name)
+            continue
+        data = blob.download_as_bytes()
+        content_type = blob.content_type or "application/x-shockwave-flash"
+        s3_client.put_object(
+            Bucket=s3_bucket,
+            Key=blob.name,
+            Body=data,
+            ContentType=content_type,
+        )
+        logging.info("uploaded %s", blob.name)
+
+
+def migrate(
+    gcs_bucket: str | None,
+    s3_bucket: str | None,
+    prefix: str = "",
+    dry_run: bool = False,
+    skip_existing: bool = False,
+) -> None:
+    if gcs_bucket is None:
+        gcs_bucket = os.environ.get("GCS_BUCKET")
+    if s3_bucket is None:
+        s3_bucket = os.environ.get("S3_BUCKET")
+    gcs_client = storage.Client()
+    s3_client = boto3.client("s3")
+    _migrate(
+        gcs_client,
+        s3_client,
+        gcs_bucket,
+        s3_bucket,
+        prefix,
+        dry_run=dry_run,
+        skip_existing=skip_existing,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="copy swf files from gcs to s3")
+    parser.add_argument("gcs_bucket", nargs="?")
+    parser.add_argument("s3_bucket", nargs="?")
+    parser.add_argument("--prefix", default="")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--skip-existing", action="store_true")
+    args = parser.parse_args()
+    migrate(
+        args.gcs_bucket,
+        args.s3_bucket,
+        args.prefix,
+        dry_run=args.dry_run,
+        skip_existing=args.skip_existing,
+    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -ra
+python_files = tests/test_*.py
+norecursedirs = bs4 cloudstorage
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ loguru==0.7.0
 uvicorn==0.22.0
 gunicorn==20.1.0
 webapp2==3.0.0b1
+boto3
+moto
+tqdm

--- a/sqlite_cli.py
+++ b/sqlite_cli.py
@@ -1,0 +1,25 @@
+"""Simple CLI for interacting with the SQLite database."""
+
+import argparse
+import json
+from sqlite_models import SQLiteDB
+
+
+def show(table: str, limit: int, db: SQLiteDB) -> None:
+    cur = db.conn.execute(f"SELECT * FROM {table} LIMIT ?", (limit,))
+    rows = cur.fetchall()
+    print(json.dumps(rows, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="query sqlite db")
+    parser.add_argument("table", help="table name")
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument("--db", default="wordgames.db")
+    args = parser.parse_args()
+    db = SQLiteDB(args.db)
+    show(args.table, args.limit, db)
+
+
+if __name__ == "__main__":
+    main()

--- a/sqlite_models.py
+++ b/sqlite_models.py
@@ -1,0 +1,104 @@
+import sqlite3
+from typing import Optional, Iterable
+
+
+class SQLiteDB:
+    """Simple wrapper around sqlite3 for storing word game data."""
+
+    def __init__(self, path: str = None):
+        if path is None:
+            import os
+            path = os.environ.get("WORDGAMES_DB", "wordgames.db")
+        self.conn = sqlite3.connect(path)
+        self.create_tables()
+
+    def create_tables(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id TEXT PRIMARY KEY,
+                cookie_user INTEGER,
+                name TEXT,
+                email TEXT,
+                profile_url TEXT,
+                access_token TEXT,
+                has_purchased INTEGER
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS games (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT,
+                urltitle TEXT UNIQUE,
+                description TEXT,
+                instructions TEXT,
+                url TEXT,
+                width INTEGER,
+                height INTEGER,
+                imgwidth INTEGER,
+                imgheight INTEGER
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS scores (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT,
+                score INTEGER,
+                difficulty INTEGER,
+                timedMode INTEGER,
+                time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS highscores (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT,
+                score INTEGER,
+                difficulty INTEGER,
+                timedMode INTEGER
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS achievements (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT,
+                type INTEGER,
+                time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS photos (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT,
+                full_size_image BLOB
+            )
+            """
+        )
+        self.conn.commit()
+
+    def insert(self, table: str, cols: Iterable[str], values: Iterable) -> None:
+        placeholders = ",".join("?" for _ in cols)
+        sql = f"INSERT INTO {table} ({','.join(cols)}) VALUES ({placeholders})"
+        self.conn.execute(sql, list(values))
+        self.conn.commit()
+
+    def fetchone(self, table: str, where: str, params: Iterable) -> Optional[tuple]:
+        sql = f"SELECT * FROM {table} WHERE {where}"
+        cur = self.conn.execute(sql, list(params))
+        return cur.fetchone()
+
+    def export_json(self, table: str) -> list:
+        cur = self.conn.execute(f"SELECT * FROM {table}")
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, row)) for row in cur.fetchall()]

--- a/tests/test_migrate_swf.py
+++ b/tests/test_migrate_swf.py
@@ -1,0 +1,68 @@
+import boto3
+from moto import mock_aws
+
+from migrate_swf_to_s3 import _migrate
+
+
+class FakeBlob:
+    def __init__(self, name, data, content_type="application/x-shockwave-flash"):
+        self.name = name
+        self._data = data
+        self.content_type = content_type
+
+    def download_as_bytes(self):
+        return self._data
+
+
+class FakeGCS:
+    def __init__(self, blobs):
+        self._blobs = blobs
+
+    def bucket(self, name):
+        return name
+
+    def list_blobs(self, bucket, prefix=""):
+        return self._blobs
+
+
+@mock_aws
+def test_migrate_swf():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket="dest")
+
+    blobs = [FakeBlob("foo.swf", b"flashdata")]
+    gcs = FakeGCS(blobs)
+
+    _migrate(gcs, s3, "src", "dest")
+
+    obj = s3.get_object(Bucket="dest", Key="foo.swf")
+    assert obj["Body"].read() == b"flashdata"
+
+
+@mock_aws
+def test_dry_run_no_upload():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket="dest")
+
+    blobs = [FakeBlob("foo.swf", b"data")]
+    gcs = FakeGCS(blobs)
+
+    _migrate(gcs, s3, "src", "dest", dry_run=True)
+
+    resp = s3.list_objects_v2(Bucket="dest")
+    assert "Contents" not in resp
+
+
+@mock_aws
+def test_skip_existing():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket="dest")
+    s3.put_object(Bucket="dest", Key="foo.swf", Body=b"old")
+
+    blobs = [FakeBlob("foo.swf", b"new")]
+    gcs = FakeGCS(blobs)
+
+    _migrate(gcs, s3, "src", "dest", skip_existing=True)
+
+    obj = s3.get_object(Bucket="dest", Key="foo.swf")
+    assert obj["Body"].read() == b"old"

--- a/tests/test_sqlite_models.py
+++ b/tests/test_sqlite_models.py
@@ -1,0 +1,40 @@
+import os
+import sqlite3
+import pytest
+
+from sqlite_models import SQLiteDB
+
+
+def test_create_and_insert(tmp_path):
+    db_path = tmp_path / "test.db"
+    db = SQLiteDB(str(db_path))
+
+    db.insert("users", ["id", "name"], ["u1", "Test"])
+    row = db.fetchone("users", "id=?", ["u1"])
+    assert row[0] == "u1"
+    assert row[2] == "Test"
+
+def test_export_json(tmp_path):
+    db_path = tmp_path / "test.db"
+    db = SQLiteDB(str(db_path))
+    db.insert("users", ["id", "name"], ["u2", "Bob"])
+    data = db.export_json("users")
+    assert data[0]["id"] == "u2"
+    assert data[0]["name"] == "Bob"
+from subprocess import check_output
+
+
+def test_cli(tmp_path):
+    db_path = tmp_path / "test.db"
+    db = SQLiteDB(str(db_path))
+    db.insert("users", ["id", "name"], ["u3", "CLI"])
+    out = check_output([
+        "python",
+        "sqlite_cli.py",
+        "users",
+        "--limit",
+        "1",
+        "--db",
+        str(db_path),
+    ])
+    assert "u3" in out.decode()


### PR DESCRIPTION
## Summary
- support SQLite storage via `sqlite_models.py`
- provide migration script from NDB to SQLite
- document SQLite usage and CLI in README
- add simple CLI and JSON export helpers
- add pytest configuration and tests
- add SWF migration tool with progress bar, dry-run, and skip options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870eb8f9a588333a17098fda060aa7d