### PR TITLE
Add theme toggle, progress bar, and streak counter

### DIFF
--- a/static/word-jumble/index.html
+++ b/static/word-jumble/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Word Jumble</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Word Jumble</h1>
+        <p id="scrambled"></p>
+        <input type="text" id="guess" placeholder="Your guess" autofocus>
+        <button id="check">Check Guess</button>
+        <button id="skip">Skip</button>
+        <p id="message"></p>
+        <p>Score: <span id="score">0</span></p>
+        <p>Lives: <span id="lives">3</span></p>
+        <p>High score: <span id="high-score">0</span></p>
+        <p>Streak: <span id="streak">0</span></p>
+        <p>Time: <span id="timer">0</span>s</p>
+        <label for="difficulty">Difficulty:</label>
+        <select id="difficulty">
+            <option value="easy">Easy</option>
+            <option value="medium">Medium</option>
+            <option value="hard">Hard</option>
+            <option value="auto">Auto</option>
+        </select>
+        <button id="pause">Pause</button>
+        <button id="hint">Hint</button>
+        <button id="show-scores">Scores</button>
+        <button id="theme-toggle">Dark Mode</button>
+    </div>
+    <div id="progress-container"><div id="progress"></div></div>
+    <div id="scoreboard" class="hidden">
+        <h2>High Scores</h2>
+        <ul id="scores-list"></ul>
+        <button id="close-scores">Close</button>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/static/word-jumble/script.js
+++ b/static/word-jumble/script.js
@@ -1,0 +1,276 @@
+const easyWords = ['cat', 'dog', 'rain', 'code', 'game'];
+const mediumWords = ['python', 'giraffe', 'computer', 'puzzle'];
+const hardWords = ['javascript', 'encyclopedia', 'programming', 'algorithm', 'variable'];
+
+let currentWord = '';
+let score = 0;
+let highScore = 0;
+let timer;
+let timeLeft = 0;
+let initialTime = 0;
+let paused = false;
+let difficulty = 'easy';
+let lives = 3;
+let scores = [];
+let streak = 0;
+const unusedWords = { easy: [...easyWords], medium: [...mediumWords], hard: [...hardWords] };
+
+function loadHighScore() {
+    if (typeof localStorage !== 'undefined') {
+        highScore = Number(localStorage.getItem('wordJumbleHighScore')) || 0;
+        const el = document.getElementById('high-score');
+        if (el) el.textContent = highScore;
+    }
+}
+
+function loadScores() {
+    if (typeof localStorage !== 'undefined') {
+        try {
+            scores = JSON.parse(localStorage.getItem('wordJumbleScores')) || [];
+        } catch (_) {
+            scores = [];
+        }
+    }
+}
+
+function saveScores() {
+    if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('wordJumbleScores', JSON.stringify(scores));
+    }
+}
+
+function saveHighScore() {
+    if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('wordJumbleHighScore', String(highScore));
+    }
+}
+
+function toggleTheme() {
+    const body = document.body;
+    const dark = body.classList.toggle('dark');
+    if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('wordJumbleTheme', dark ? 'dark' : 'light');
+    }
+}
+
+function getWordList(currentScore = score) {
+    if (difficulty === 'auto') {
+        if (currentScore < 5) return easyWords;
+        if (currentScore < 10) return mediumWords;
+        return hardWords;
+    }
+    if (difficulty === 'easy') return easyWords;
+    if (difficulty === 'medium') return mediumWords;
+    return hardWords;
+}
+
+function getUniqueWord(list, key) {
+    if (!unusedWords[key] || unusedWords[key].length === 0) {
+        unusedWords[key] = [...list];
+    }
+    const idx = Math.floor(Math.random() * unusedWords[key].length);
+    return unusedWords[key].splice(idx, 1)[0];
+}
+
+function updateScoreboard() {
+    const list = document.getElementById('scores-list');
+    if (!list) return;
+    list.innerHTML = '';
+    scores.slice(0, 5).forEach((s) => {
+        const li = document.createElement('li');
+        li.textContent = s;
+        list.appendChild(li);
+    });
+}
+
+function showScores() {
+    const sb = document.getElementById('scoreboard');
+    sb.classList.remove('hidden', 'fade-out');
+    sb.classList.add('visible');
+    updateScoreboard();
+}
+
+function hideScores() {
+    const sb = document.getElementById('scoreboard');
+    sb.classList.remove('visible');
+    sb.classList.add('fade-out');
+    setTimeout(() => {
+        sb.classList.add('hidden');
+        sb.classList.remove('fade-out');
+    }, 500);
+}
+
+function endGame() {
+    clearInterval(timer);
+    scores.push(score);
+    scores.sort((a, b) => b - a);
+    saveScores();
+    showScores();
+    score = 0;
+    streak = 0;
+    lives = 3;
+    document.getElementById('score').textContent = score;
+    document.getElementById('lives').textContent = lives;
+    document.getElementById('streak').textContent = streak;
+    pickWord();
+}
+
+function loseLife() {
+    lives--;
+    document.getElementById('lives').textContent = lives;
+    if (lives <= 0) {
+        document.getElementById('message').textContent += ' Game over!';
+        endGame();
+    } else {
+        pickWord();
+        startTimer();
+        const container = document.querySelector('.container');
+        container.classList.add('shake', 'flash');
+        setTimeout(() => container.classList.remove('flash'), 500);
+        streak = 0;
+        document.getElementById('streak').textContent = streak;
+    }
+}
+
+function shuffle(word) {
+    const arr = word.split('');
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr.join('');
+}
+
+function pickWord() {
+    const list = getWordList();
+    let diffKey = difficulty;
+    if (difficulty === 'auto') {
+        diffKey = score < 5 ? 'easy' : score < 10 ? 'medium' : 'hard';
+    }
+    currentWord = getUniqueWord(list, diffKey);
+    const scrambledEl = document.getElementById('scrambled');
+    scrambledEl.textContent = shuffle(currentWord);
+    scrambledEl.classList.add('fade-in');
+    setTimeout(() => scrambledEl.classList.remove('fade-in'), 300);
+    document.getElementById('guess').value = '';
+    document.getElementById('message').textContent = '';
+    const baseTime = 30;
+    const reduction = Math.min(score * 2, 20);
+    timeLeft = Math.max(10, baseTime - reduction);
+    initialTime = timeLeft;
+    document.getElementById('progress').style.width = '100%';
+    document.querySelector('.container').classList.remove('shake', 'correct');
+}
+
+function startTimer() {
+    clearInterval(timer);
+    document.getElementById('timer').textContent = timeLeft;
+    timer = setInterval(() => {
+        if (!paused) {
+            timeLeft--;
+            document.getElementById('timer').textContent = timeLeft;
+            document.getElementById('progress').style.width = `${Math.max(0, (timeLeft / initialTime) * 100)}%`;
+            if (timeLeft <= 0) {
+                clearInterval(timer);
+                document.getElementById('message').textContent = `Time's up! The word was ${currentWord}.`;
+                loseLife();
+            }
+        }
+    }, 1000);
+}
+
+function checkGuess() {
+    const guess = document.getElementById('guess').value.trim().toLowerCase();
+    if (guess === currentWord) {
+        score++;
+        document.getElementById('score').textContent = score;
+        streak++;
+        document.getElementById('streak').textContent = streak;
+        if (score > highScore) {
+            highScore = score;
+            document.getElementById('high-score').textContent = highScore;
+            saveHighScore();
+        }
+        document.getElementById('message').textContent = 'Correct!';
+        document.querySelector('.container').classList.add('correct');
+        pickWord();
+        startTimer();
+    } else {
+        document.getElementById('message').textContent = 'Try again!';
+        loseLife();
+    }
+}
+
+function togglePause() {
+    paused = !paused;
+    document.getElementById('pause').textContent = paused ? 'Resume' : 'Pause';
+}
+
+function setDifficulty(val) {
+    difficulty = val;
+}
+
+function setScore(val) {
+    score = val;
+}
+
+function showHint() {
+    document.getElementById('message').textContent = `Hint: starts with ${currentWord.charAt(0)}`;
+}
+
+if (typeof window !== 'undefined') {
+    document.getElementById('check').addEventListener('click', checkGuess);
+
+    document.getElementById('skip').addEventListener('click', () => {
+        pickWord();
+        startTimer();
+    });
+
+    document.getElementById('pause').addEventListener('click', togglePause);
+    document.getElementById('hint').addEventListener('click', showHint);
+    document.getElementById('difficulty').addEventListener('change', (e) => {
+        difficulty = e.target.value;
+        pickWord();
+        startTimer();
+    });
+
+    document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+
+    if (typeof localStorage !== 'undefined') {
+        const savedTheme = localStorage.getItem('wordJumbleTheme');
+        if (savedTheme === 'dark') {
+            document.body.classList.add('dark');
+        }
+    }
+
+    document.getElementById('show-scores').addEventListener('click', showScores);
+    document.getElementById('close-scores').addEventListener('click', hideScores);
+
+    document.getElementById('guess').addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            checkGuess();
+        }
+    });
+    loadHighScore();
+    loadScores();
+    document.getElementById('lives').textContent = lives;
+    pickWord();
+    startTimer();
+}
+
+// Export for tests if running in Node
+if (typeof module !== 'undefined') {
+    module.exports = {
+        shuffle,
+        loadScores,
+        saveScores,
+        getWordList,
+        setDifficulty,
+        setScore,
+        getUniqueWord,
+        toggleTheme,
+        easyWords,
+        mediumWords,
+        hardWords
+    };
+}

--- a/static/word-jumble/style.css
+++ b/static/word-jumble/style.css
@@ -1,0 +1,130 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f7f7f7;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+    color: #333;
+}
+
+body.dark {
+    background-color: #222;
+    color: #eee;
+}
+.container {
+    background: #fff;
+    padding: 20px 30px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    text-align: center;
+}
+body.dark .container {
+    background: #333;
+}
+#scrambled {
+    font-size: 2rem;
+    margin-bottom: 10px;
+    letter-spacing: 5px;
+}
+#message {
+    font-weight: bold;
+    margin-top: 10px;
+}
+
+select, button {
+    margin-top: 10px;
+    margin-right: 5px;
+}
+
+#scoreboard {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(255, 255, 255, 0.9);
+    padding: 20px 30px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.3);
+    text-align: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.5s ease;
+}
+body.dark #scoreboard {
+    background: rgba(51, 51, 51, 0.9);
+}
+
+.hidden {
+    display: none;
+}
+
+#scoreboard.visible {
+    opacity: 1;
+    pointer-events: auto;
+    animation: fadeIn 0.5s forwards;
+}
+
+#scoreboard.fade-out {
+    animation: fadeOut 0.5s forwards;
+    pointer-events: none;
+}
+
+.correct {
+    animation: pop 0.5s ease;
+}
+
+.shake {
+    animation: shake 0.5s;
+}
+
+.flash {
+    animation: flash 0.5s;
+}
+
+.fade-in {
+    animation: fadeIn 0.3s;
+}
+
+#progress-container {
+    width: 100%;
+    background: #ddd;
+    height: 8px;
+    margin-top: 10px;
+}
+
+#progress {
+    width: 100%;
+    height: 100%;
+    background: #4caf50;
+    transition: width 1s linear;
+}
+
+@keyframes pop {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.3); }
+    100% { transform: scale(1); }
+}
+
+@keyframes shake {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-5px); }
+    75% { transform: translateX(5px); }
+}
+
+@keyframes flash {
+    0% { background-color: #fff; }
+    50% { background-color: #ffeb3b; }
+    100% { background-color: #fff; }
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}

--- a/tests/test_word_jumble.py
+++ b/tests/test_word_jumble.py
@@ -1,0 +1,93 @@
+import pathlib
+import re
+
+BASE = pathlib.Path('static/word-jumble')
+
+def test_files_exist():
+    assert (BASE / 'index.html').exists(), 'index.html missing'
+    assert (BASE / 'style.css').exists(), 'style.css missing'
+    assert (BASE / 'script.js').exists(), 'script.js missing'
+
+def test_html_links():
+    html = (BASE / 'index.html').read_text()
+    assert 'style.css' in html
+    assert 'script.js' in html
+    assert 'high-score' in html
+    assert 'id="lives"' in html
+    assert '<select id="difficulty"' in html
+    assert 'id="pause"' in html
+    assert 'id="hint"' in html
+    assert 'id="show-scores"' in html
+    assert 'id="scoreboard"' in html
+    assert '<option value="auto"' in html
+    assert 'id="theme-toggle"' in html
+    assert 'id="progress-container"' in html
+    assert 'id="streak"' in html
+
+def test_shuffle_function():
+    import subprocess, json, os, textwrap
+    node_script = textwrap.dedent('''
+        const { shuffle } = require('./static/word-jumble/script.js');
+        const result = shuffle('hello');
+        console.log(JSON.stringify({result}));
+    ''')
+    proc = subprocess.run(['node', '-e', node_script], capture_output=True, text=True)
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout.strip())['result']
+    assert sorted(out) == sorted('hello')
+    assert out != 'hello'
+
+def test_script_contains_localstorage():
+    js = (BASE / 'script.js').read_text()
+    assert 'localStorage' in js
+
+def test_css_has_animations():
+    css = (BASE / 'style.css').read_text()
+    assert '@keyframes pop' in css
+    assert '@keyframes shake' in css
+    assert '@keyframes fadeIn' in css
+    assert '@keyframes fadeOut' in css
+    assert '@keyframes flash' in css
+    assert '#progress-container' in css
+
+def test_load_scores_function():
+    import subprocess, json, textwrap
+    node_script = textwrap.dedent('''
+        const { loadScores, saveScores } = require('./static/word-jumble/script.js');
+        saveScores();
+        const data = loadScores ? typeof loadScores : null;
+        console.log(JSON.stringify({data}));
+    ''')
+    proc = subprocess.run(['node', '-e', node_script], capture_output=True, text=True)
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout.strip())['data']
+    assert out == 'function'
+
+def test_auto_difficulty_wordlist():
+    import subprocess, json, textwrap
+    node_script = textwrap.dedent('''
+        const { getWordList, setDifficulty, setScore, mediumWords } = require('./static/word-jumble/script.js');
+        setDifficulty('auto');
+        setScore(7);
+        const list = getWordList();
+        console.log(JSON.stringify({ok: JSON.stringify(list) === JSON.stringify(mediumWords)}));
+    ''')
+    proc = subprocess.run(['node', '-e', node_script], capture_output=True, text=True)
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout.strip())['ok']
+    assert out
+
+def test_unique_word_selection():
+    import subprocess, json, textwrap
+    node_script = textwrap.dedent('''
+        const { getUniqueWord, easyWords } = require('./static/word-jumble/script.js');
+        const used = new Set();
+        for (let i = 0; i < easyWords.length; i++) {
+            used.add(getUniqueWord(easyWords, 'easy'));
+        }
+        console.log(JSON.stringify({unique: used.size === easyWords.length}));
+    ''')
+    proc = subprocess.run(['node', '-e', node_script], capture_output=True, text=True)
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout.strip())['unique']
+    assert out


### PR DESCRIPTION
## Summary
- allow switching between light and dark mode
- show streak counter and timer progress bar
- ensure words do not repeat until lists cycle
- expose helper for unique word selection
- update and expand tests for new UI features

## Testing
- `pytest tests/test_word_jumble.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d933aa3c833399ea83091023511b