### PR TITLE
Add user-uploaded games with custom frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ provided via the `GCS_BUCKET` and `S3_BUCKET` environment variables.
 Users can now upload their own games with a custom frame colour. Run the server
 and navigate to `/upload-user-game` to submit a new game. Uploaded games are
 stored in the SQLite database and can be viewed at `/user-games` or `/my-games`
-when logged in.
+when logged in. The upload form contains a hidden honeypot field to deter bots,
+and games record their upload date automatically.

--- a/main.py
+++ b/main.py
@@ -412,6 +412,9 @@ class UploadUserGameHandler(BaseHandler):
         frame = self.request.get('frame')
         width = int(self.request.get('width', 800))
         height = int(self.request.get('height', 600))
+        # Simple honeypot check: bots filling the hidden field are ignored
+        if self.request.get('hp'):
+            self.abort(400)
         DB.insert_user_game(self.current_user.id, title, url, frame, width, height)
         self.redirect('/my-games')
 
@@ -428,6 +431,7 @@ class MyGamesHandler(BaseHandler):
                 'frame': r[4],
                 'width': r[5],
                 'height': r[6],
+                'created_at': r[7],
             }
             for r in rows
         ]
@@ -446,6 +450,7 @@ class UserGamesHandler(BaseHandler):
                 'frame': r[4],
                 'width': r[5],
                 'height': r[6],
+                'created_at': r[7],
             }
             for r in rows
         ]
@@ -465,6 +470,7 @@ class PlayUploadedGameHandler(BaseHandler):
             'frame': row[4],
             'width': row[5],
             'height': row[6],
+            'created_at': row[7],
         }
         self.render('/templates/user_games/play-user-game.jinja2', {'game': game})
 
@@ -482,6 +488,7 @@ class EditUserGameHandler(BaseHandler):
             'frame': row[4],
             'width': row[5],
             'height': row[6],
+            'created_at': row[7],
         }
         self.render('/templates/user_games/edit-user-game.jinja2', {'game': game})
 
@@ -489,7 +496,9 @@ class EditUserGameHandler(BaseHandler):
         frame = self.request.get('frame')
         width = int(self.request.get('width', 800))
         height = int(self.request.get('height', 600))
-        DB.update_user_game(int(game_id), frame, width, height)
+        title = self.request.get('title')
+        url = self.request.get('url')
+        DB.update_user_game(int(game_id), frame, width, height, title, url)
         self.redirect('/my-games')
 
 

--- a/templates/user_games/all-games.jinja2
+++ b/templates/user_games/all-games.jinja2
@@ -3,7 +3,10 @@
 <h1>User Uploaded Games</h1>
 <ul>
 {% for game in games %}
-  <li><a href="/play-user-game/{{ game.id }}">{{ game.title }}</a></li>
+  <li>
+    <a href="/play-user-game/{{ game.id }}">{{ game.title }}</a>
+    - uploaded {{ game.created_at[:10] }}
+  </li>
 {% endfor %}
 </ul>
 <p><a href="/upload-user-game">Upload your own</a></p>

--- a/templates/user_games/edit-user-game.jinja2
+++ b/templates/user_games/edit-user-game.jinja2
@@ -3,11 +3,14 @@
 <body>
 <h1>Edit Game</h1>
 <form method="post">
+    <label>Title: <input type="text" name="title" value="{{ game.title }}" required></label><br>
+    <label>URL: <input type="text" name="url" value="{{ game.url }}" required></label><br>
     <label>Frame Color: <input type="text" name="frame" value="{{ game.frame }}"></label><br>
     <label>Width: <input type="number" name="width" value="{{ game.width }}"></label><br>
     <label>Height: <input type="number" name="height" value="{{ game.height }}"></label><br>
     <button type="submit">Update</button>
 </form>
 <p><a href="/my-games">Back</a></p>
+<p>Uploaded {{ game.created_at[:10] }}</p>
 </body>
 </html>

--- a/templates/user_games/my-games.jinja2
+++ b/templates/user_games/my-games.jinja2
@@ -5,6 +5,7 @@
 {% for game in games %}
   <li>
     <a href="/play-user-game/{{ game.id }}">{{ game.title }}</a>
+    - uploaded {{ game.created_at[:10] }}
     (<a href="/edit-user-game/{{ game.id }}">edit</a>
     <a href="/delete-user-game/{{ game.id }}">delete</a>)
   </li>

--- a/templates/user_games/play-user-game.jinja2
+++ b/templates/user_games/play-user-game.jinja2
@@ -1,5 +1,6 @@
 <!doctype html>
 <html><head><title>{{ game.title }}</title></head>
 <body style="margin:0; background-color: {{ game.frame }}">
+<p>Uploaded {{ game.created_at[:10] }}</p>
 <iframe src="{{ game.url }}" style="border:5px solid {{ game.frame }}; width: {{ game.width }}px; height: {{ game.height }}px;"></iframe>
 </body></html>

--- a/templates/user_games/upload-user-game.jinja2
+++ b/templates/user_games/upload-user-game.jinja2
@@ -9,6 +9,7 @@
     <label>Frame Color: <input type="text" name="frame" value="#000000"></label><br>
     <label>Width: <input type="number" name="width" value="800"></label><br>
     <label>Height: <input type="number" name="height" value="600"></label><br>
+    <input type="text" name="hp" style="display:none">
     <button type="submit">Save</button>
 </form>
 <p><a href="/my-games">My Games</a></p>

--- a/tests/test_sqlite_models.py
+++ b/tests/test_sqlite_models.py
@@ -48,8 +48,11 @@ def test_user_games_table(tmp_path):
     assert row[2] == "My Game"
     assert row[3] == "http://example.com"
     assert row[4] == "#111"
-    db.update_user_game(row[0], "#222", 800, 600)
+    assert row[7] is not None
+    db.update_user_game(row[0], "#222", 800, 600, "New Title", "http://new")
     updated = db.fetch_user_game(row[0])
+    assert updated[2] == "New Title"
+    assert updated[3] == "http://new"
     assert updated[4] == "#222"
     db.delete_user_game(row[0])
     assert db.fetch_user_game(row[0]) is None


### PR DESCRIPTION
## Summary
- support user-uploaded games in SQLite
- provide handlers and templates for uploading and managing games
- allow editing and deleting uploaded games
- add tests for new SQLite helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e8be9fd88333a83645d38f168431